### PR TITLE
Use UTF8 String Encoding for Import/Export

### DIFF
--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -54,7 +54,7 @@ com.updatecopy = {
                     stringValue = unescape(textLayer.stringValue().replace(/[\r\n]+/g, ' ')),
                     name = unescape(textLayer.name());
 
-            csv_string += "\"" + name + "\",\"" + stringValue + "\"\n";
+            csv_string += "\"" + name + "\";\"" + stringValue + "\"\n";
         }
 
         return csv_string;
@@ -163,10 +163,10 @@ com.updatecopy = {
             // It's looking for lines in a key,value format
             // Key and value may each be surronded by quotes
             var expressions = [
-              /^([^"]+?),([^"]+?)$/mg,
-              /^([^"]+?),"([\S\s]+)"$/mg,
-              /^"([\S\s]+)",([^"]+?)$/mg,
-              /^"([\S\s]+)","([\S\s]+)"$/mg,
+              /^([^"]+?);([^"]+?)$/mg,
+              /^([^"]+?);"([\S\s]+)"$/mg,
+              /^"([\S\s]+)";([^"]+?)$/mg,
+              /^"([\S\s]+)";"([\S\s]+)"$/mg,
             ];
 
           var data = {};

--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -51,7 +51,7 @@ com.updatecopy = {
 
         for (var i = 0; i < textLayers.length; i++) {
             var textLayer = textLayers[i],
-                    stringValue = unescape(textLayer.stringValue()),
+                    stringValue = unescape(textLayer.stringValue().replace(/[\r\n]+/g, ' ')),
                     name = unescape(textLayer.name());
 
             csv_string += "\"" + name + "\",\"" + stringValue + "\"\n";

--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -11,6 +11,7 @@ com.updatecopy = {
         var app = [NSApplication sharedApplication];
         [app displayDialog:msg withTitle:title];
     },
+
     getTextLayersForPage: function(page) {
         var layers = [page children],
                 textLayers = [];
@@ -36,7 +37,9 @@ com.updatecopy = {
 
     isExportTextLayer: function(textLayer) {
         var nameStringValue = unescape(textLayer.name());
-        if (nameStringValue.search('__')) {
+        var isVisible = textLayer.isVisible();
+
+        if (nameStringValue.search('__') && isVisible) {
             return true;
         }
 

--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -87,7 +87,7 @@ com.updatecopy = {
             if ([panel runModal] == NSOKButton) {
                 var url = [panel URL];
                 var cocoaString = [NSString stringWithFormat:"%@", string];
-                [cocoaString writeToURL:url atomically:false encoding:NSUTF16StringEncoding error:nil];
+                [cocoaString writeToURL:url atomically:false encoding:NSUTF8StringEncoding error:nil];
             }
             return true;
         }
@@ -173,7 +173,7 @@ com.updatecopy = {
             for (var i = 0; i < urls.count(); i++) {
                 url = urls[i];
                 filename = [[url lastPathComponent] stringByDeletingPathExtension];
-                getString = NSString.stringWithContentsOfFile_encoding_error(url, NSUTF16StringEncoding, null);
+                getString = NSString.stringWithContentsOfFile_encoding_error(url, NSUTF8StringEncoding, null);
 
                 if(getString){
                     var contents = getString.toString();

--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -80,10 +80,11 @@ com.updatecopy = {
         return true;
     },
 
-    /*  ---------- begin markgoetz edits: save the text to a file instead of to the clipboard.  ---------- */
     saveStringToFile: function(string) {
         try {
             var panel = NSSavePanel.savePanel();
+            var extension = NSArray.alloc().initWithObjects("csv", nil);
+            panel.setAllowedFileTypes(extension);
             if ([panel runModal] == NSOKButton) {
                 var url = [panel URL];
                 var cocoaString = [NSString stringWithFormat:"%@", string];
@@ -95,7 +96,6 @@ com.updatecopy = {
             log(e);
         }
     },
-    /* ---------- end markgoetz edits ---------- */
 
     updatePageWithData: function(page, language, data) {
         var pageName = [page name],

--- a/sketch-copyeditor/library/copyeditor.js
+++ b/sketch-copyeditor/library/copyeditor.js
@@ -84,7 +84,7 @@ com.updatecopy = {
             if ([panel runModal] == NSOKButton) {
                 var url = [panel URL];
                 var cocoaString = [NSString stringWithFormat:"%@", string];
-                [cocoaString writeToURL:url atomically:false encoding:NSWindowsCP1252StringEncoding error:nil];
+                [cocoaString writeToURL:url atomically:false encoding:NSUTF16StringEncoding error:nil];
             }
             return true;
         }
@@ -170,7 +170,7 @@ com.updatecopy = {
             for (var i = 0; i < urls.count(); i++) {
                 url = urls[i];
                 filename = [[url lastPathComponent] stringByDeletingPathExtension];
-                getString = NSString.stringWithContentsOfFile_encoding_error(url, NSWindowsCP1252StringEncoding, null);
+                getString = NSString.stringWithContentsOfFile_encoding_error(url, NSUTF16StringEncoding, null);
 
                 if(getString){
                     var contents = getString.toString();


### PR DESCRIPTION
In order to be able to use special characters in texts (our designers often use characters like ▾ in the design) I’ve changed the encoding to UTF8 to support that.
